### PR TITLE
Properly exit the program.

### DIFF
--- a/include/Poll.hpp
+++ b/include/Poll.hpp
@@ -32,6 +32,7 @@ class Poll {
         size_t getSize(void) const;
         Socket *getSocket(size_t index);
         short  getEventReturn(size_t index);
+        void   clear(void);
 
 	    class PollError : public std::exception
 		{

--- a/include/Socket.hpp
+++ b/include/Socket.hpp
@@ -30,7 +30,7 @@ class Socket {
 		int         getFd(void) const;
         void        setFd(int fd);
 
-        void        bind(void);
+        void        bind(int optval);
         void        listen(int backlog);
         void        accept(int serverFd);
         int         send(const std::string response);

--- a/include/WebServer.hpp
+++ b/include/WebServer.hpp
@@ -28,6 +28,7 @@ class WebServer {
 		WebServer &operator=(WebServer const &other);
 
 		void	run(void); // Temporary configuration because I don't have the parser yet.
+        void    stop(void);
 };
 
 std::ostream &operator<<(std::ostream &out, WebServer const &in);

--- a/include/libs.hpp
+++ b/include/libs.hpp
@@ -13,24 +13,28 @@
 #ifndef LIBS_HPP
 # define LIBS_HPP
 
-# include <iostream>
-# include <string>
-# include <sstream>
-# include <sys/socket.h>
-# include <sys/types.h>
-# include <unistd.h>
-# include <stdlib.h>
-# include <netinet/in.h>
-# include <string.h>
-# include <errno.h>
-# include <vector>
-# include <poll.h>
-# include <arpa/inet.h>
-# include <fcntl.h>
-# include <netdb.h>
-# include <unistd.h>
-# include <fcntl.h>
-# include <algorithm>
+// C LIBRARIES
+
+# include <arpa/inet.h>      // Functions to convert IP addresses.
+# include <errno.h>          // Error codes to indicate system call errors.
+# include <fcntl.h>          // File control operations like fcntl.
+# include <netdb.h>          // Functions to perform DNS lookups and IP address conversions.
+# include <netinet/in.h>     // Internet address-related data types and macros.
+# include <poll.h>           // The poll system call for I/O multiplexing.
+# include <stdlib.h>         // Standard C library.
+# include <string.h>         // C-style string functions like strlen and strcpy.
+# include <sys/socket.h>     // Socket-related system calls.
+# include <sys/types.h>      // System types like pid_t and size_t.
+# include <unistd.h>         // System calls like read, write, and close.
+
+// C++ LIBRARIES
+
+# include <algorithm>        // STL algorithms.
+# include <csignal>          // Signal handling.
+# include <iostream>         // Standard input/output operations.
+# include <sstream>          // Parsing strings.
+# include <string>           // String data type and its operations.
+# include <vector>           // Vector container class.
 
 
 #endif

--- a/src/Poll.cpp
+++ b/src/Poll.cpp
@@ -75,17 +75,31 @@ bool	Poll::verifyEvenReturn(short revents)
 	return (false);
 }
 
-size_t Poll::getSize(void) const 
+size_t  Poll::getSize(void) const 
 {
 	return (this->_pollfds.size());
 }
 
-Socket *Poll::getSocket(size_t index)
+Socket  *Poll::getSocket(size_t index)
 {
     return (this->_sockets[index]);
 }
 
-short  Poll::getEventReturn(size_t index)
+short   Poll::getEventReturn(size_t index)
 {
     return (this->_pollfds[index].revents);
+}
+
+void    Poll::clear(void)
+{
+    for (std::vector<pollfd>::reverse_iterator it = _pollfds.rbegin(); it != _pollfds.rend(); ++it)
+    {
+        std::cout << "Closing fd " << it->fd << std::endl;
+        ::close(it->fd);
+    }
+    _pollfds.clear();
+
+    for (std::vector<Socket*>::reverse_iterator it = _sockets.rbegin(); it != _sockets.rend(); ++it) 
+        delete *it;
+    _sockets.clear();
 }

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -52,7 +52,7 @@ void Socket::setFd(int fd)
     return;
 }
 
-void    Socket::bind(void)
+void    Socket::bind(int optval)
 {
     struct addrinfo info, *response;
     std::stringstream ss;
@@ -65,6 +65,8 @@ void    Socket::bind(void)
     info.ai_flags = AI_PASSIVE;
 
     getaddrinfo(NULL, port.c_str(), &info, &response);
+
+    setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
     
     if (::bind(_fd, response->ai_addr, response->ai_addrlen) < 0)
         throw (BindSocketError());

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -14,19 +14,19 @@
 
 WebServer::WebServer(void) 
 {
-	std::cout << "Hello, this is your WebServer ready to go!\n";
+	std::cout << "Hello, this is your WebServer ready to go!" << std::endl;
 	return ;
 }
 
 WebServer::~WebServer(void) 
 {
-	std::cout << "Bye bye!";
+	std::cout << "Bye bye!" << std::endl;
 	return ;
 }
 
 WebServer::WebServer(WebServer const &other) 
 {
-	std::cout << "WebServer copy constructor called\n";
+	std::cout << "WebServer copy constructor called" << std::endl;
 	*this = other;
 	return ;
 }
@@ -34,7 +34,7 @@ WebServer::WebServer(WebServer const &other)
 WebServer &WebServer::operator=(WebServer const &other)
 {   	
     if (this != &other) {
-		std::cout << "WebServer copy assignment operator called\n";
+		std::cout << "WebServer copy assignment operator called" << std::endl;
 	}
 	return (*this);
 }
@@ -49,8 +49,8 @@ void WebServer::run(void)
 
     for(int i = 0; i < 3; i++) // hardcoded number of sockets because I have no input file yet.
     {
-        listener = new Socket(ports[i]); // sockets allocated with new will have to be explicitly deleted.
-        listener->bind();
+        listener = new Socket(ports[i]);
+        listener->bind(1); // 1 for forcefully releasing port, 0 for not doing that.
         listener->listen(SOMAXCONN); // add some sort of error handling to this, do not add socket to poll() if binding/listening fails.
         this->_poll.insertSocket(listener);
     }
@@ -93,11 +93,16 @@ void WebServer::run(void)
                             std::cerr << "\e[0;31mError: unable to receive request data on fd" << client->getFd() << "\e[0m" << std::endl;
                     }
                     this->_poll.removeSocket(client);
-                    client->close(); // listeners sockets will need to be explicitly closed on server shutdown.
                 }
             }
         }
     }
+}
+
+void WebServer::stop(void)
+{
+    std::cout << "Stopping Webserver..." << std::endl;
+    this->_poll.clear(); // in the future will also have to clear server data, request data, etc.
 }
 
 std::ostream &operator<<(std::ostream &out, WebServer const &in) 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,15 @@
 # include "libs.hpp"
 # include "WebServer.hpp"
 
+WebServer webserver;
+
+void    interrupt(int sig)
+{
+    std::cout << std::endl << "Signal " << sig << " called." << std::endl;
+    webserver.stop();
+    exit(0);
+}
+
 int main(int argc, char **argv)
 {
     if (argc < 2)
@@ -23,7 +32,11 @@ int main(int argc, char **argv)
     std::string input = argv[1];
     if (input.compare("GO!") == 0)
     {
-        WebServer webserver;
+        struct sigaction interruptHandler;
+        interruptHandler.sa_handler = interrupt;
+        sigemptyset(&interruptHandler.sa_mask);
+        interruptHandler.sa_flags = 0;
+        sigaction(SIGINT, &interruptHandler, 0);
 
         webserver.run();
     }


### PR DESCRIPTION
- Adds `Webserv::stop()` and `Poll::clear()` methods to properly deallocate memory and empty used structures.
- Adds signal handler to catch SIGINT and trigger `Webserv::stop()`.
- Adds an option of using [setsockopt ](https://linux.die.net/man/3/setsockopt)to allow reuse of local addresses on binding, to avoid errors when shutting down the server and bringing it back up quickly.