### PR TITLE
[PARSING] Handle Location blocks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ SRCS		=	$(DIR_SRCS)/main.cpp \
 				$(DIR_SRCS)/ParseDirectives.cpp \
 				$(DIR_SRCS)/ftstring.cpp \
 				$(DIR_SRCS)/Server.cpp \
+				$(DIR_SRCS)/Location.cpp \
 
 BUILD		=	$(subst $(DIR_SRCS), $(DIR_BUILD), $(SRCS:.cpp=.o))
 

--- a/include/Location.hpp
+++ b/include/Location.hpp
@@ -17,6 +17,7 @@
 
 class Location {
     private:
+        std::string                                      _path;
         std::map<std::string, std::vector<std::string> > _locationData;
     
     public:
@@ -27,6 +28,8 @@ class Location {
 
         void                        insertLocationData(std::pair<std::string, std::vector<std::string> > directive);
         std::vector<std::string>    getValue(std::string key);    
+		void						setPath(std::string path);
+		std::string					getPath(void);
 
         class DuplicateDirectiveError : public std::exception
 		{

--- a/include/Location.hpp
+++ b/include/Location.hpp
@@ -1,0 +1,51 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Location.hpp                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/04/21 21:53:40 by lcouto            #+#    #+#             */
+/*   Updated: 2023/04/21 21:53:40 by lcouto           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef  LOCATION_HPP
+# define LOCATION_HPP
+
+# include "libs.hpp"
+
+class Location {
+    private:
+        std::map<std::string, std::vector<std::string> > _locationData;
+    
+    public:
+    	Location(void);
+        ~Location(void);
+		// Location(Location const &other);
+		// Location &operator=(Location const &other);
+
+        void                        insertLocationData(std::pair<std::string, std::vector<std::string> > directive);
+        std::vector<std::string>    getValue(std::string key);    
+
+        class DuplicateDirectiveError : public std::exception
+		{
+			public:
+				virtual const char* what() const throw()
+				{
+					return ("\e[0;31mError: directives 'autoindex' and 'root' must be unique.\e[0m");
+				}
+		};
+
+        class DirectiveNotAllowedError : public std::exception
+		{
+			public:
+				virtual const char* what() const throw()
+				{
+					return ("\e[0;31mError: directives not allowed inside location block'.\e[0m");
+				}
+		};
+
+};
+
+#endif

--- a/include/ParseConfig.hpp
+++ b/include/ParseConfig.hpp
@@ -41,7 +41,7 @@ class ParseConfig {
 		std::string				findDirective(std::string line);
 		void    				processServer(std::string serverBlock);
 		void 					splitOffLocationBlocks(std::string &serverBlock, Server &server);
-		void 					processLocation(std::string locationBlock); //pass location reference
+		void 					processLocation(std::string locationBlock, Location &location);
 
 	    class ParseSyntaxError : public std::exception
 		{

--- a/include/ParseConfig.hpp
+++ b/include/ParseConfig.hpp
@@ -16,6 +16,7 @@
 # include "libs.hpp"
 # include "ParseDirectives.hpp"
 # include "Server.hpp"
+# include "Location.hpp"
 
 class ParseConfig {
     private:
@@ -39,6 +40,8 @@ class ParseConfig {
         bool    				checkServerBlock(void);
 		std::string				findDirective(std::string line);
 		void    				processServer(std::string serverBlock);
+		void 					splitOffLocationBlocks(std::string &serverBlock, Server &server);
+		void 					processLocation(std::string locationBlock); //pass location reference
 
 	    class ParseSyntaxError : public std::exception
 		{

--- a/include/ParseDirectives.hpp
+++ b/include/ParseDirectives.hpp
@@ -26,7 +26,6 @@ class ParseDirectives {
         static DirectiveType parseIndex(std::string const &line);
         static DirectiveType parseLimitExcept(std::string const &line);
         static DirectiveType parseListen(std::string const &line);
-        static DirectiveType parseLocation(std::string const &line);
         static DirectiveType parseRedirect(std::string const &line);
         static DirectiveType parseRoot(std::string const &line);
         static DirectiveType parseServerName(std::string const &line);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -30,6 +30,7 @@ class Server {
         void                        insertServerData(std::pair<std::string, std::vector<std::string> > directive);
         std::vector<std::string>    getValue(std::string key);
         void                        insertLocation(Location location);
+		std::vector<Location>		getLocations(void);
 
         class DuplicateDirectiveError : public std::exception
 		{

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -14,11 +14,12 @@
 # define SERVER_HPP
 
 # include "libs.hpp"
+# include "Location.hpp"
 
 class Server {
     private:
-        std::map<std::string, std::vector<std::string> > _serverData;
-        // std::vector<Location>                         _locations;
+        std::map<std::string, std::vector<std::string> >    _serverData;
+        std::vector<Location>                               _locations;
     
     public:
     	Server(void);
@@ -27,7 +28,8 @@ class Server {
 		// Server &operator=(Server const &other);
 
         void                        insertServerData(std::pair<std::string, std::vector<std::string> > directive);
-        std::vector<std::string>    getValue(std::string key);    
+        std::vector<std::string>    getValue(std::string key);
+        void                        insertLocation(Location location);
 
         class DuplicateDirectiveError : public std::exception
 		{

--- a/include/WebServer.hpp
+++ b/include/WebServer.hpp
@@ -18,6 +18,7 @@
 # include "Poll.hpp"
 # include "ParseConfig.hpp"
 # include "Server.hpp"
+# include "Location.hpp"
 
 class WebServer {
     private:

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -49,3 +49,13 @@ std::vector<std::string>    Location::getValue(std::string key)
     
     return value;
 }
+
+void    Location::setPath(std::string path)
+{
+    this->_path = path;
+}
+
+std::string Location::getPath(void)
+{
+    return this->_path;
+}

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -1,0 +1,51 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Location.cpp                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/04/21 21:53:47 by lcouto            #+#    #+#             */
+/*   Updated: 2023/04/21 21:53:47 by lcouto           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+# include "Location.hpp"
+
+Location::Location(void)
+{
+	return ;
+}
+
+Location::~Location(void) 
+{
+	return ;
+}
+
+void    Location::insertLocationData(std::pair<std::string, std::vector<std::string> > directive)
+{
+    bool    isUniqueDirective = (directive.first == "root" || directive.first == "autoindex");
+    bool    directiveNotOnMap = (this->_locationData.find(directive.first) != this->_locationData.end());
+
+    if (isUniqueDirective)
+        if (directiveNotOnMap)
+            throw (DuplicateDirectiveError());
+        else
+            this->_locationData.insert(directive);
+    else
+        if (directiveNotOnMap)
+            this->_locationData.insert(directive);
+        else
+            this->_locationData[directive.first].insert(this->_locationData[directive.first].begin(), directive.second.begin(), directive.second.end());
+}
+
+std::vector<std::string>    Location::getValue(std::string key)
+{
+    std::vector<std::string> value;
+
+    std::map<std::string, std::vector<std::string> >::iterator it = this->_locationData.find(key);
+    if (it != _locationData.end())
+        value = it->second;
+    
+    return value;
+}

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -25,18 +25,19 @@ Location::~Location(void)
 void    Location::insertLocationData(std::pair<std::string, std::vector<std::string> > directive)
 {
     bool    isUniqueDirective = (directive.first == "root" || directive.first == "autoindex");
-    bool    directiveNotOnMap = (this->_locationData.find(directive.first) != this->_locationData.end());
+    bool    isDirectiveOnMap = (this->_locationData.find(directive.first) != this->_locationData.end());
 
-    if (isUniqueDirective)
-        if (directiveNotOnMap)
+    if (isUniqueDirective) {
+        if (isDirectiveOnMap)
             throw (DuplicateDirectiveError());
         else
             this->_locationData.insert(directive);
-    else
-        if (directiveNotOnMap)
+    } else {
+        if (isDirectiveOnMap)
             this->_locationData.insert(directive);
         else
             this->_locationData[directive.first].insert(this->_locationData[directive.first].begin(), directive.second.begin(), directive.second.end());
+    }
 }
 
 std::vector<std::string>    Location::getValue(std::string key)

--- a/src/ParseConfig.cpp
+++ b/src/ParseConfig.cpp
@@ -139,10 +139,8 @@ std::string ParseConfig::findDirective(std::string line)
 void ParseConfig::processServer(std::string serverBlock)
 {
     serverBlock = ftstring::trim(serverBlock, " {}\t\v\f\r");
-    std::cout << "\nBLOCK START\n" <<  serverBlock << "\nBLOCK END\n" <<  std::endl;
-
     Server server;
-
+    splitOffLocationBlocks(serverBlock, server);
     std::istringstream iss(serverBlock);
     std::string line, key;
 
@@ -157,4 +155,27 @@ void ParseConfig::processServer(std::string serverBlock)
 
     this->_serverData.push_back(server);
 }
+
+void ParseConfig::splitOffLocationBlocks(std::string &serverBlock, Server &server)
+{
+    Location location;
+    std::string delimiter = "location ";
+    size_t pos = 0;
+
+    while ((pos = serverBlock.find(delimiter, pos)) != std::string::npos) {
+        size_t blockStart = pos;
+        size_t blockEnd = serverBlock.find_first_of('}', pos);
+
+        processLocation(serverBlock.substr(blockStart, blockEnd - blockStart + 1)); //pass location reference
+        server.insertLocation(location);
+        serverBlock.erase(blockStart, blockEnd - blockStart + 1);
+        pos = blockStart;
+    }
+}
+
+void ParseConfig::processLocation(std::string locationBlock) //pass location reference
+{
+    std::cout << "\nBLOCK START\n" << locationBlock << "\nBLOCK END\n" <<  std::endl;
+}
+
 

--- a/src/ParseDirectives.cpp
+++ b/src/ParseDirectives.cpp
@@ -68,14 +68,6 @@ ParseDirectives::DirectiveType ParseDirectives::parseListen(const std::string &l
     return data;
 }
 
-ParseDirectives::DirectiveType ParseDirectives::parseLocation(const std::string &line)
-{
-    ParseDirectives::DirectiveType data;
-    data.first = "location";
-    data.second.push_back(line);
-    return data;
-}
-
 ParseDirectives::DirectiveType ParseDirectives::parseRedirect(const std::string &line)
 {
     ParseDirectives::DirectiveType data;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -54,3 +54,8 @@ void    Server::insertLocation(Location location)
 {
     this->_locations.push_back(location);
 }
+
+std::vector<Location>    Server::getLocations(void)
+{
+    return this->_locations;
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -25,18 +25,19 @@ Server::~Server(void)
 void    Server::insertServerData(std::pair<std::string, std::vector<std::string> > directive)
 {
     bool    isUniqueDirective = (directive.first == "root" || directive.first == "client_max_body_size" || directive.first == "autoindex" || directive.first == "listen");
-    bool    directiveNotOnMap = (this->_serverData.find(directive.first) != this->_serverData.end());
+    bool    isDirectiveOnMap = (this->_serverData.find(directive.first) != this->_serverData.end());
 
-    if (isUniqueDirective)
-        if (directiveNotOnMap)
+    if (isUniqueDirective) {
+        if (isDirectiveOnMap)
             throw (DuplicateDirectiveError());
         else
             this->_serverData.insert(directive);
-    else
-        if (directiveNotOnMap)
+    } else {
+        if (isDirectiveOnMap)
             this->_serverData.insert(directive);
         else
             this->_serverData[directive.first].insert(this->_serverData[directive.first].begin(), directive.second.begin(), directive.second.end());
+    }
 }
 
 std::vector<std::string>    Server::getValue(std::string key)

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -49,3 +49,8 @@ std::vector<std::string>    Server::getValue(std::string key)
     
     return value;
 }
+
+void    Server::insertLocation(Location location)
+{
+    this->_locations.push_back(location);
+}

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -49,11 +49,18 @@ void WebServer::run(const std::string &inputFilePath)
 
     this->_serverData = this->_parseConfig.execute(inputFilePath);
 
+    // vvvvv PRINTING FOR TESTING - REMOVE THIS BLOCK vvvvv
+
     for (size_t i = 0; i < this->_serverData.size(); i++)
     {
         std::vector<std::string> value = this->_serverData[i].getValue("listen");
-        std::cout << "\e[0;32m" << value[0] << "\e[0m" << std::endl;
+        std::cout << "\e[1;32m" << value[0] << "\e[0m" << std::endl;
+        std::vector<Location> locations = this->_serverData[i].getLocations();
+        for (size_t i = 0; i < locations.size(); i++)
+            std::cout << "\e[0;32m" << locations[i].getPath() << "\e[0m" << std::endl;
     }
+
+    // ^^^^^ PRINTING FOR TESTING - REMOVE THIS BLOCK ^^^^^
 
     for(int i = 0; i < 3; i++) // hardcoded number of sockets because I have no input file yet.
     {

--- a/testconfig.conf
+++ b/testconfig.conf
@@ -6,11 +6,11 @@
         root /var/www/
         error_page 404 404.html
         
-        location /dir/website/ {
+        location /dir/website/1/ {
             autoindex on
     }
 
-        location /dir/website/ {
+        location /dir/website/x/ {
             autoindex off
     }
 
@@ -27,7 +27,7 @@
         error_page 500 500.html
         client_max_body_size 1m
         
-        location /dir/website2/ {
+        location /dir/website12345/ {
             autoindex off
             redirect /dir/redirectpage/
     }
@@ -39,7 +39,7 @@
         root /var/www/
         error_page 404 404.html
         
-        location /dir/website3/ {
+        location /dir/website3/site/ {
             limit_except GET POST
     }
 }

--- a/testconfig.conf
+++ b/testconfig.conf
@@ -4,18 +4,27 @@
         listen 443
         index index.html index.php
         root /var/www/
-        error_page 404.html 500.html
+        error_page 404 404.html
         
         location /dir/website/ {
             autoindex on
+    }
+
+        location /dir/website/ {
+            autoindex off
+    }
+
+         location /dir/website2/ {
+            autoindex off
+            redirect /dir/redirectpage/
     }
 }
 
     server {
         listen 80
         index index.html index.php
-        error_page 404.html
-        error_page 500.html
+        error_page 404 404.html
+        error_page 500 500.html
         client_max_body_size 1m
         
         location /dir/website2/ {
@@ -28,7 +37,7 @@
         listen 1234
         index index.html index.php
         root /var/www/
-        error_page 404.html 500.html
+        error_page 404 404.html
         
         location /dir/website3/ {
             limit_except GET POST


### PR DESCRIPTION
- Add the `Location` class
- in `ParseConfig`, split off location blocks and use them to feed their info/directives into a `Location` object.
- Add vector of `Location`s into the properties of the `Server` class.
- Remove the `parseLocation` function from `ParseDirectives`, as the location block is being treated inside `ParseConfig`.

Example structure:
![image](https://user-images.githubusercontent.com/57910428/233870553-98debe0d-a824-4bcd-8a75-9845b37ecef6.png)
