### PR TITLE
[WEBSERVER] Pass correct server data to response object.

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -21,6 +21,7 @@ class Server {
     private:
         std::map<std::string, std::vector<std::string> > _serverData;
         std::vector<Location>                            _locations;
+        int                                              _fd;
 
     public:
         Server(void);
@@ -31,6 +32,9 @@ class Server {
 
         std::vector<std::string> getValue(std::string key);
         std::vector<Location>    getLocations(void);
+
+        int     getFd(void);
+        void    setFd(int fd);
 
         class DuplicateDirectiveError : public std::exception {
             public:

--- a/include/Socket.hpp
+++ b/include/Socket.hpp
@@ -20,6 +20,7 @@ class Socket {
         std::string _port;
         std::string _ip;
         int         _fd;
+        int         _serverFd;
 
     public:
         Socket(std::string port = "8080", std::string ip = "127.0.0.1");
@@ -27,17 +28,19 @@ class Socket {
         Socket(Socket const &other);
         Socket &operator=(Socket const &other);
 
-        void socket(void);
-        void bind(int optval);
-        void listen(int backlog);
-        void connect(int backlog);
-        void accept(int serverFd);
-        int  send(std::string const response);
-        int  receive(std::string &request);
-        void close();
+        void        socket(void);
+        void        bind(int optval);
+        void        listen(int backlog);
+        void        connect(int backlog);
+        void        accept(int serverFd);
+        int         send(std::string const response);
+        int         receive(std::string &request);
+        void        close();
 
-        int  getFd(void) const;
-        void setFd(int fd);
+        int         getFd(void) const;
+        void        setFd(int fd);
+        std::string getPort(void) const;
+        int         getServerFd(void) const;
 
         class CreateSocketError : public std::exception {
             public:

--- a/include/WebServer.hpp
+++ b/include/WebServer.hpp
@@ -39,10 +39,14 @@ class WebServer {
         void run(std::string const &inputFilePath);
         void init(std::string const &inputFilePath);
         void stop(void);
+        void setServerSocketFds(void);
+
+        Server  *getCurrentServer(int fd);
 
         int sockaccept(Socket *listener);
         int sockreceive(Socket *client);
         int socksend(Socket *client);
+
 };
 
 std::ostream &operator<<(std::ostream &out, WebServer const &in);

--- a/serverdatatest.conf
+++ b/serverdatatest.conf
@@ -1,0 +1,20 @@
+    server {
+        listen 3007
+        index hello.html
+        root examples
+        error_page 404 404.html
+}
+
+    server {
+        listen 3010
+        index webserv.pdf
+        root examples/pdfs
+        error_page 404 404.html
+}
+
+    server {
+        listen 3020
+        index bolo.jpg
+        root examples/images
+        error_page 404 404.html
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -50,6 +50,10 @@ void Server::insertLocation(Location location) { this->_locations.push_back(loca
 
 std::vector<Location> Server::getLocations(void) { return this->_locations; }
 
+int     Server::getFd(void) { return this->_fd; }
+
+void    Server::setFd(int fd) { this->_fd = fd; }
+
 bool Server::_isUniqueDirective(std::string const &directive) const
 {
     char const  *uniqueDirectives[] = {"root", "client_max_body_size", "autoindex", "listen"};

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -12,7 +12,7 @@
 
 #include "Socket.hpp"
 
-Socket::Socket(std::string port, std::string ip) : _port(port), _ip(ip), _fd(-1) {}
+Socket::Socket(std::string port, std::string ip) : _port(port), _ip(ip), _fd(-1), _serverFd(-1) {}
 
 Socket::Socket(Socket const &other) { *this = other; }
 
@@ -69,6 +69,7 @@ void Socket::accept(int serverFd)
     newFd = ::accept(serverFd, (struct sockaddr *)&clientAddr, &clientAddrLen);
     if (newFd < 0)
         throw AcceptSocketError();
+    _serverFd = serverFd;
     _fd = newFd;
 }
 
@@ -115,3 +116,7 @@ void Socket::close(void)
 int Socket::getFd(void) const { return this->_fd; }
 
 void Socket::setFd(int fd) { this->_fd = fd; }
+
+std::string Socket::getPort(void) const { return this->_port; }
+
+int Socket::getServerFd(void) const { return this->_serverFd; }


### PR DESCRIPTION
- Adds a socket's file descriptor to the `Server` object with the correspondent `port` number.
- Allows a client socket to store/retrieve the FD of the listener socket bound to it.
- Uses this information to select the correct server block to pass to a `Response` object.