### PR TITLE
[RESPONSE] Implement redirect directive.

### DIFF
--- a/examples/redirect/hello.html
+++ b/examples/redirect/hello.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Redirected!</title>
+    <style>
+        body {
+            background-color: #0f507a;
+            font-family: 'Open Sans', sans-serif;
+            color: #fff;
+            text-align: center;
+            padding-top: 100px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        h1 {
+            font-size: 48px;
+            margin-bottom: 50px;
+        }
+        p {
+            font-size: 24px;
+            margin-bottom: 25px;
+        }
+        .content {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            justify-content: center;
+        }
+        .thumbs-up {
+            max-width: 50%;
+            height: auto;
+            margin-bottom: 5%;
+            margin-right: 50px;
+        }
+    </style>
+</head>
+<body>
+    <h1>You've Been Redirected!</h1>
+    <div class="content">
+        <img src="https://i.pinimg.com/originals/27/d5/1a/27d51a2ec6ee3c0a340584e9ba6d79e7.jpg" alt="d._." class="thumbs-up">
+    </div>
+</body>
+</html>

--- a/hello.conf
+++ b/hello.conf
@@ -15,3 +15,22 @@
             index webserv.pdf
         }
 }
+
+    server {
+        listen 3008
+        index hello.html
+        root examples
+        redirect examples/redirect
+        error_page 404 notfound.html
+
+        location /images {
+            limit_except GET
+            autoindex on
+            error_page 404 nocake.html
+        }
+
+        location /pdfs {
+            index webserv.pdf
+        }
+
+}


### PR DESCRIPTION
Minimal implementation of the `redirect` directive. Replaces `root` in the main server block with the desired path and returns 301. Works with GET/POST/DELETE.