### PR TITLE
[RESPONSE] Add handler function for the server_name directive

### DIFF
--- a/hello.conf
+++ b/hello.conf
@@ -1,5 +1,6 @@
     server {
         listen 3007
+        server_name lcouto.42.fr 
         index hello.html
         root examples
         autoindex on

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -6,7 +6,7 @@
 /*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/27 23:27:45 by lcouto            #+#    #+#             */
-/*   Updated: 2023/05/09 01:47:02 by lcouto           ###   ########.fr       */
+/*   Updated: 2023/05/11 00:20:09 by lcouto           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,7 @@ class Response {
         void deleteResource(std::string requestURI);
         void HTTPError(std::string status);
         void setErrorPage(std::string status, std::string path);
+        void validateServerName(void);
 
         std::vector<std::string> verifyLocationAutoindexOverride(std::string resourcePath);
 

--- a/include/ResponseTools.hpp
+++ b/include/ResponseTools.hpp
@@ -6,7 +6,7 @@
 /*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/01 01:31:07 by lcouto            #+#    #+#             */
-/*   Updated: 2023/05/09 00:03:17 by lcouto           ###   ########.fr       */
+/*   Updated: 2023/05/11 00:49:00 by lcouto           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,8 @@ class ResponseTools {
         static bool         isDirectory(std::string path);
         static bool         isRequestMethodAllowed(std::string method, std::vector<std::string> limitExcept);
         static size_t       convertMaxBodySizeToNumber(std::string maxSize);
-        static std::string  autoindex(std::string path, std::string port); 
+        static std::string  autoindex(std::string path, std::string port);
+        static std::string  getCurrentDate(void);
         static void         initStatusCodes(std::map<std::string, std::string> &statusCodes);
         static void         initContentTypes(std::map<std::string, std::string> &contentTypes);
 };

--- a/include/libs.hpp
+++ b/include/libs.hpp
@@ -37,6 +37,7 @@
 
 #include <algorithm> // STL algorithms.
 #include <csignal>   // Signal handling.
+#include <ctime>     // Time and date functions.
 #include <fstream>   // File stream.
 #include <iostream>  // Standard input/output operations.
 #include <map>       // Map container class.

--- a/src/ResponseTools.cpp
+++ b/src/ResponseTools.cpp
@@ -6,7 +6,7 @@
 /*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/01 01:33:38 by lcouto            #+#    #+#             */
-/*   Updated: 2023/05/09 00:48:43 by lcouto           ###   ########.fr       */
+/*   Updated: 2023/05/11 00:57:57 by lcouto           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -141,6 +141,19 @@ std::string ResponseTools::autoindex(std::string path, std::string port)
     indexPage += "</p>\n</body>\n</html>\n";
     closedir(dir);
     return indexPage;
+}
+
+std::string ResponseTools::getCurrentDate(void)
+{
+    time_t now;
+    std::tm *local_time;
+    char buffer[64];
+
+    now = std::time(NULL);
+    local_time = std::localtime(&now);
+    std::strftime(buffer, 64, "%a, %d %b %Y %T %Z", local_time);
+
+    return buffer;
 }
 
 void ResponseTools::initStatusCodes(std::map<std::string, std::string> &statusCodes)


### PR DESCRIPTION
Adds verification to see if the `Host` header sent via the HTTP Request matches any of the server names specified in the configuration file. In case it does not, the server mimics Nginx's behavior and returns 404. Host name must be added to the `hosts` file for testing. Also adds the server spec and current date to response headers.