### PR TITLE
[REFACTOR] Clear request class

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/23 21:44:23 by lcouto            #+#    #+#             */
-/*   Updated: 2023/05/11 19:35:55 by maolivei         ###   ########.fr       */
+/*   Updated: 2023/05/11 21:55:08 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,9 +16,34 @@
 #include "libs.hpp"
 
 class Request {
-    private:
-
     public:
+        Request(void);
+        Request(std::map<std::string, std::string> headers,
+                std::string                        method,
+                std::string                        requestURI,
+                std::string                        protocol,
+                std::string                        body,
+                std::string                        raw,
+                std::string                        errorCode = "",
+                bool                               hasError  = false);
+        ~Request(void);
+        Request(Request const &other);
+        Request &operator=(Request const &other);
+
+        std::map<std::string, std::string> const &getHeaders(void) const;
+
+        std::string const &getMethod(void) const;
+        std::string const &getRequestURI(void) const;
+        std::string const &getProtocol(void) const;
+        std::string const &getBody(void) const;
+        std::string const &getRawRequest(void) const;
+        std::string const &getErrorCode(void) const;
+
+        void setError(std::string const &errorCode);
+
+        bool hasError(void) const;
+
+    private:
         std::map<std::string, std::string> _headers;
         std::string                        _method;
         std::string                        _requestURI;
@@ -26,38 +51,8 @@ class Request {
         std::string                        _body;
         std::string                        _raw;
 
-        bool        hasError;
-        std::string errorCode;
-
-        Request(void);
-        Request(std::string raw);
-        ~Request(void);
-        Request(Request const &other);
-        Request &operator=(Request const &other);
-
-        std::map<std::string, std::string> getHeaders(void);
-        std::string                        getMethod(void);
-        std::string                        getRequestURI(void);
-        std::string                        getProtocol(void);
-        std::string                        getBody(void);
-        std::string                        getRawRequest(void);
-
-        void setRawRequest(std::string raw);
-
-        void parse(void);
-        void parseRequestLine(std::stringstream &rawStream);
-        void parseHeaders(std::stringstream &rawStream);
-        void parseBody(std::stringstream &rawStream);
-
-        void clear(void);
-
-        class EmptyRequestError : public std::exception {
-            public:
-                virtual char const *what() const throw()
-                {
-                    return ("\e[0;31mError: cannot parse empty request\e[0m");
-                }
-        };
+        bool        _hasError;
+        std::string _errorCode;
 };
 
 std::ostream &operator<<(std::ostream &out, Request &in);

--- a/include/RequestTools.hpp
+++ b/include/RequestTools.hpp
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/01 01:31:07 by lcouto            #+#    #+#             */
-/*   Updated: 2023/05/11 20:17:26 by maolivei         ###   ########.fr       */
+/*   Updated: 2023/05/11 21:59:24 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,6 @@
 
 class RequestTools {
     private:
-        Request     _request;
         Server     *_server;
         std::string _raw;
 
@@ -52,6 +51,15 @@ class RequestTools {
         std::string::const_iterator _header_key_begin;
         std::string::const_iterator _header_value_begin;
 
+        std::map<std::string, std::string> _headers;
+        std::string                        _method;
+        std::string                        _uri;
+        std::string                        _protocol;
+        std::string                        _body;
+
+        bool        _hasError;
+        std::string _errorCode;
+
     public:
         RequestTools(std::string &raw, Server *server);
         ~RequestTools(void);
@@ -60,7 +68,7 @@ class RequestTools {
 
         void parseRequest(void);
 
-        Request getRequest(void) const;
+        Request buildRequest(void) const;
 
         class RequestParsingException : public std::exception {
             public:

--- a/src/RequestTools.cpp
+++ b/src/RequestTools.cpp
@@ -6,14 +6,13 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/08 18:25:27 by maolivei          #+#    #+#             */
-/*   Updated: 2023/05/11 20:45:16 by maolivei         ###   ########.fr       */
+/*   Updated: 2023/05/11 21:58:30 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "RequestTools.hpp"
 
 RequestTools::RequestTools(std::string &raw, Server *server) :
-    _request(Request(raw)),
     _server(server),
     _raw(raw),
     _max_body_size(-1),
@@ -40,7 +39,6 @@ RequestTools::RequestTools(RequestTools const &src) { *this = src; }
 RequestTools &RequestTools::operator=(RequestTools const &src)
 {
     if (this != &src) {
-        _request               = src._request;
         _server                = src._server;
         _raw                   = src._raw;
         _max_body_size         = src._max_body_size;
@@ -64,8 +62,8 @@ void RequestTools::parseRequest(void)
 
         if (_has_body) {
             std::map<std::string, std::string>::const_iterator it;
-            it = _request._headers.find("transfer-encoding");
-            if (it != _request._headers.end()) {
+            it = _headers.find("transfer-encoding");
+            if (it != _headers.end()) {
                 std::string              te_values = ftstring::reduce(it->second, ", ");
                 std::vector<std::string> te_split  = ftstring::split(te_values, ' ');
                 if (te_split.back() == "chunked")
@@ -75,21 +73,24 @@ void RequestTools::parseRequest(void)
 
         if (_has_chunked_body) {
             _parseChunkedBody();
-            _request._body = _chunk_data;
+            _body = _chunk_data;
         } else if (_has_body) {
             _parseRegularBody();
-            _request._body = _body_data;
+            _body = _body_data;
         }
     } catch (RequestParsingException const &e) {
         std::cerr << e.get_error() << ' ' << e.what() << '\n';
-        _request.hasError  = true;
-        _request.errorCode = e.get_error();
+        _hasError  = true;
+        _errorCode = e.get_error();
     } catch (std::exception const &e) {
         std::cerr << e.what() << '\n';
     }
 }
 
-Request RequestTools::getRequest(void) const { return (_request); }
+Request RequestTools::buildRequest(void) const
+{
+    return (Request(_headers, _method, _uri, _protocol, _body, _raw, _errorCode, _hasError));
+}
 
 /******************************************** PRIVATE ********************************************/
 
@@ -127,11 +128,10 @@ void RequestTools::_parseRequestLine(void)
 
             case WSV_METHOD:
                 if (*it == WHITESPACE) {
-                    std::string method(_method_begin, it);
-                    if (!_isValidMethod(method))
+                    _method.assign(_method_begin, it);
+                    if (!_isValidMethod(_method))
                         throw RequestParsingException(NOT_IMPLEMENTED);
-                    _request._method = method;
-                    state            = WSV_URI_START;
+                    state = WSV_URI_START;
                 }
                 break;
 
@@ -144,9 +144,8 @@ void RequestTools::_parseRequestLine(void)
 
             case WSV_URI:
                 if (*it == WHITESPACE) {
-                    std::string uri(_uri_begin, it);
-                    _request._requestURI = uri;
-                    state                = WSV_HTTP_START;
+                    _uri.assign(_uri_begin, it);
+                    state = WSV_HTTP_START;
                     break;
                 }
                 if (_isControlCharacter(*it))
@@ -216,9 +215,8 @@ void RequestTools::_parseRequestLine(void)
 
             case WSV_MINOR_DIGIT:
                 if (*it == CR) {
-                    std::string protocol(_protocol_begin, it);
-                    _request._protocol = protocol;
-                    state              = WSV_REQUEST_ALMOST_DONE;
+                    _protocol.assign(_protocol_begin, it);
+                    state = WSV_REQUEST_ALMOST_DONE;
                     break;
                 }
                 if (*it < '0' || *it > '9')
@@ -337,8 +335,8 @@ void RequestTools::_parseRegularBody(void)
     if (!_ignore_content_length) {
         std::map<std::string, std::string>::const_iterator it;
 
-        it = _request._headers.find("content-length");
-        if (it != _request._headers.end()) {
+        it = _headers.find("content-length");
+        if (it != _headers.end()) {
             size_t content_length = ftstring::strtoi(it->second);
             if (content_length > _max_body_size)
                 throw RequestParsingException(ENTITY_TOO_LARGE);
@@ -551,11 +549,11 @@ void RequestTools::_headerFieldNormalizedInsert(std::string &key, std::string &v
     std::transform(key.begin(), key.end(), key.begin(), ::tolower);
     std::transform(value.begin(), value.end(), value.begin(), ::tolower);
 
-    std::map<std::string, std::string>::iterator it = _request._headers.find(key);
-    if (it != _request._headers.end())
+    std::map<std::string, std::string>::iterator it = _headers.find(key);
+    if (it != _headers.end())
         it->second += ", " + value;
     else
-        _request._headers[key] = value;
+        _headers[key] = value;
 }
 
 /************************************ REQUEST PARSING EXCEPTION ***********************************/

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -6,7 +6,7 @@
 /*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/27 23:27:53 by lcouto            #+#    #+#             */
-/*   Updated: 2023/05/11 19:16:57 by maolivei         ###   ########.fr       */
+/*   Updated: 2023/05/11 22:00:03 by maolivei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -440,7 +440,6 @@ void Response::validateServerName(void)
 
 void Response::clear(void)
 {
-    this->_request.clear();
     this->_responseString.clear();
     this->_statusLine.clear();
     this->_headers.clear();

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -85,15 +85,14 @@ int WebServer::socksend(Socket *client)
     Request      request;
 
     parser.parseRequest();
-    request = parser.getRequest();
-
-    Response response(request);
+    request = parser.buildRequest();
 
     std::cout << request << std::endl; // Debugging purposes
 
+    Response response(request);
     response.setServerData(getCurrentServer(client->getServerFd()));
-    if (request.hasError)
-        response.HTTPError(request.errorCode);
+    if (request.hasError())
+        response.HTTPError(request.getErrorCode());
     response.assembleResponseString();
     if (client->send(response.getResponseString()) <= 0) {
         std::cerr << "\e[0;31mError: unable to receive request data on fd" << client->getFd()


### PR DESCRIPTION
- Refactor `Request` class, keeping only members and getters for those members, and removing unused parsing functions that have been moved to `RequestTools`;
- Replace `insert()` for `assign()` inside `RequestTools`, so strings don't have to be cleared often.