### PR TITLE
[BUG] Fix errors on client_max_body_size handling 

### DIFF
--- a/examples/methods/too_large.html
+++ b/examples/methods/too_large.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Método POST</title>
+  <title>Tudo tem limite!</title>
   <style>
     * {
       overflow: hidden;
@@ -81,12 +81,12 @@
 
         var formData = new FormData(form);
 
-        fetch("http://localhost:3008/methods/image.jpg", {
+        fetch("http://localhost:3009/methods/image.jpg", {
           method: "POST",
           body: formData
         })
         .then(function(response) {
-          window.location.href = "http://localhost:3008/methods/post.html";
+          window.location.href = "http://localhost:3009/methods/too_large.html";
         })
         .catch(function(error) {
           console.log("Error:", error);
@@ -98,23 +98,24 @@
 <body>
   <div class="content">
     <div class="text-box">
-      <h1>Método POST</h1>
+      <h1>Tudo tem limite!</h1>
       <p>
-        O método POST permite que o usuário envie uma entidade (feita de bytes, não um fantasma) para
-        o endereço desejado, causando uma mudança de estado ou efeitos colaterais no servidor.
+        Na página anterior, podíamos enviar qualquer arquivo com o formato .jpg para o nosso Webserv.
+        Mas o que podemos fazer para impedir que um usuário entupa o nosso servidor com arquivos gigantescos?
+        Afinal, nada te impede de mandar uma imagem com a resolução de um outdoor em 600dpi.
       </p>
       <p>
-        Neste caso, você pode escolher uma imagem com o formato .jpg para enviar para o Webserv,
-        que substituirá a que está nessa página.
+        Para isso, usamos a diretiva <i>client max body size</i>, que, nesse caso, impede que imagems de tamanho
+        acima de 200 kilobytes sejam enviadas para o nosso server. Faça o experimento!
       </p>
       <br>
-      <form action="http://localhost:3008/methods/image.jpg" method="POST" enctype="multipart/form-data">
+      <form action="http://localhost:3009/methods/image.jpg" method="POST" enctype="multipart/form-data">
         <input type="file" name="image" accept="image/jpeg">
         <input type="submit" value="Enviar 🖼️" class="button">
       </form>
       <p>
         <br>
-        <a href="http://localhost:3009/methods/too_large.html" class="button">Próxima página! ➡️</a>
+        <a href="http://localhost:3008/methods/delete.html" class="button">Próxima página! ➡️</a>
       </p>
     </div>
     <div class="image">

--- a/guided_tour.conf
+++ b/guided_tour.conf
@@ -47,6 +47,7 @@ server {
 
     location /methods {
         error_page 404 custom_404.html
+        client_max_body_size 200
         autoindex off
     }
 

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Response.cpp                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/27 23:27:53 by lcouto            #+#    #+#             */
-/*   Updated: 2023/05/31 21:13:54 by maolivei         ###   ########.fr       */
+/*   Updated: 2023/06/03 00:44:02 by lcouto           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -293,18 +293,31 @@ void Response::getResource(std::string requestURI)
 void Response::postResource(std::string requestURI)
 {
     std::string resource;
+    std::vector<std::string> maxSizeVector;
 
-    std::vector<std::string> maxSizeVector = this->_serverData->getValue("client_max_body_size");
+    std::vector<Location> locations = this->_serverData->getLocations();
+    if (!locations.empty()) {
+        for (size_t i = 0; i < locations.size(); i++) {
+            if (requestURI.find(locations[i].getPath()) != std::string::npos) {
+                maxSizeVector = locations[i].getValue("client_max_body_size");
+                break;
+            }
+        }
+    }
+
+    if (maxSizeVector.empty())
+        maxSizeVector = this->_serverData->getValue("client_max_body_size");
+
     if (!maxSizeVector.empty()) {
         size_t maxSize = ResponseTools::convertMaxBodySizeToNumber(maxSizeVector[0]);
 
         if (this->_request.getBody().length() > maxSize) {
+            std::cout << this->_request.getBody().length() << std::endl;
             HTTPError("413");
             return;
         }
     }
 
-    std::vector<Location> locations = this->_serverData->getLocations();
     if (!locations.empty()) {
         for (size_t i = 0; i < locations.size(); i++) {
 

--- a/src/ResponseTools.cpp
+++ b/src/ResponseTools.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ResponseTools.cpp                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maolivei <maolivei@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/01 01:33:38 by lcouto            #+#    #+#             */
-/*   Updated: 2023/05/30 16:37:32 by maolivei         ###   ########.fr       */
+/*   Updated: 2023/06/03 00:58:18 by lcouto           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,7 +100,7 @@ size_t ResponseTools::convertMaxBodySizeToNumber(std::string maxSize)
         ++it;
     }
     if (it == maxSize.end()) {
-        return (value);
+        return (value * 1024);
     }
     if (*it == 'm' || *it == 'M') {
         return (value * 1024 * 1024);


### PR DESCRIPTION
- Allows the user to define a `client_max_body_size` directive for separate locations.
- Fixes error in the `convertMaxBodySizeToNumber()` function that returned values in kilobytes instead of bytes.
- Adds test page for the `client_max_body_size` directive.